### PR TITLE
am2rlauncher: init at 2.3.0-unstable-2023-11-08

### DIFF
--- a/.github/workflows/update-packages.yaml
+++ b/.github/workflows/update-packages.yaml
@@ -14,6 +14,6 @@ jobs:
       - name: Update flake packages
         uses: devusb/nix-update-action@unstable-version
         with:
-          blacklist: "igb,pgdiff,quakejs,dreamm,xmltv,message-bridge"
+          blacklist: "am2rlauncher,igb,pgdiff,quakejs,dreamm,xmltv,message-bridge"
           branch: "update_packages_action"
           pr-title: "Update packages"

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
             let
               blacklistPackages = {
                 "aarch64-darwin" = [
+                  "am2rlauncher"
                   "quakejs"
                   "igb"
                   "starship-sf64"
@@ -81,6 +82,7 @@
                   "message-bridge"
                 ];
                 "aarch64-linux" = [
+                  "am2rlauncher"
                   "message-bridge"
                 ];
               };

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,5 @@
 final: prev: {
+  am2rlauncher = final.callPackage ./pkgs/am2rlauncher { };
   go-simple-upload-server = final.callPackage ./pkgs/go-simple-upload-server { };
   wolweb = final.callPackage ./pkgs/wolweb { };
   jellyplex-watched = final.callPackage ./pkgs/jellyplex-watched { };

--- a/pkgs/am2rlauncher/am2r-run-binary.patch
+++ b/pkgs/am2rlauncher/am2r-run-binary.patch
@@ -1,0 +1,14 @@
+diff --git a/AM2RLauncher/AM2RLauncherLib/Profile.cs b/AM2RLauncher/AM2RLauncherLib/Profile.cs
+index 8186350..2f9de2a 100644
+--- a/AM2RLauncher/AM2RLauncherLib/Profile.cs
++++ b/AM2RLauncher/AM2RLauncherLib/Profile.cs
+@@ -796,7 +796,8 @@ public static class Profile
+                 UseShellExecute = false,
+                 WorkingDirectory = gameDirectory,
+                 #if NOAPPIMAGE
+-                FileName = $"{gameDirectory}/runner"
++                FileName = "am2r-run",
++                Arguments = "./runner"
+                 #else
+                 FileName = $"{gameDirectory}/AM2R.AppImage"
+                 #endif

--- a/pkgs/am2rlauncher/default.nix
+++ b/pkgs/am2rlauncher/default.nix
@@ -1,0 +1,154 @@
+{
+  lib,
+  pkgsi686Linux,
+  buildDotnetModule,
+  buildFHSEnv,
+  writeShellScript,
+  runCommand,
+  glibc,
+  gtk3,
+  libappindicator,
+  webkitgtk_4_1,
+  e2fsprogs,
+  libnotify,
+  libgit2,
+  openssl,
+  xdelta,
+  file,
+  openjdk,
+  patchelf,
+  fetchFromGitHub,
+  glib-networking,
+  wrapGAppsHook3,
+  gsettings-desktop-schemas,
+  dotnetCorePackages,
+}:
+let
+  am2r-run = buildFHSEnv {
+    name = "am2r-run";
+
+    multiArch = true;
+
+    multiPkgs =
+      pkgs: with pkgs; [
+        (lib.getLib stdenv.cc.cc)
+        libx11
+        libxext
+        libxrandr
+        libxxf86vm
+        curl
+        mesa
+        libGLU
+        libglvnd
+        openal
+        zlib
+      ];
+
+    extraBuildCommandsMulti =
+      let
+        openssl_1_0_2_i686 = pkgsi686Linux.callPackage ./openssl-1.0.nix { };
+      in
+      ''
+        ln -s ${openssl_1_0_2_i686.out}/lib/libssl.so.1.0.0 $out/usr/lib32/
+        ln -s ${openssl_1_0_2_i686.out}/lib/libcrypto.so.1.0.0 $out/usr/lib32/
+      '';
+
+    runScript = writeShellScript "am2r-run" ''
+      exec -- "$1" "$@"
+    '';
+  };
+
+  webkitgtk-4_0-compat = runCommand "webkitgtk-4.0-compat" { } ''
+    mkdir -p $out/lib
+    for name in libwebkit2gtk-4.0.so libwebkit2gtk-4.0.so.37; do
+      ln -s ${webkitgtk_4_1}/lib/libwebkit2gtk-4.1.so.0 $out/lib/$name
+    done
+    for name in libjavascriptcoregtk-4.0.so libjavascriptcoregtk-4.0.so.18; do
+      ln -s ${webkitgtk_4_1}/lib/libjavascriptcoregtk-4.1.so.0 $out/lib/$name
+    done
+  '';
+in
+buildDotnetModule {
+  pname = "am2rlauncher";
+  version = "2.3.0-unstable-2023-11-08";
+
+  src = fetchFromGitHub {
+    owner = "AM2R-Community-Developers";
+    repo = "AM2RLauncher";
+    rev = "5d8b7d9b3de68e6215c10b9fd223b7f1d5e40dea";
+    hash = "sha256-/nHqo8jh3sOUngbpqdfiQjUWO/8Uzpc5jtW7Ep4q6Wg=";
+  };
+
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  projectFile = "AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj";
+
+  nugetDeps = ./deps.json;
+  executables = "AM2RLauncher.Gtk";
+
+  runtimeDeps = [
+    glibc
+    gtk3
+    libappindicator
+    webkitgtk_4_1
+    webkitgtk-4_0-compat
+    e2fsprogs
+    libnotify
+    libgit2
+    openssl
+  ];
+
+  nativeBuildInputs = [ wrapGAppsHook3 ];
+
+  buildInputs = [
+    gtk3
+    gsettings-desktop-schemas
+    glib-networking
+  ];
+
+  patches = [
+    ./am2r-run-binary.patch
+    ./dotnet-8-upgrade.patch
+  ];
+
+  dotnetFlags = [
+    ''-p:DefineConstants="NOAPPIMAGE;NOAUTOUPDATE"''
+  ];
+
+  makeWrapperArgs = [
+    "--prefix"
+    "PATH"
+    ":"
+    (lib.escapeShellArg (
+      lib.makeBinPath [
+        am2r-run
+        xdelta
+        file
+        openjdk
+        patchelf
+      ]
+    ))
+  ];
+
+  postFixup = ''
+    mkdir -p $out/share/icons
+    install -Dm644 $src/AM2RLauncher/distribution/linux/AM2RLauncher.png $out/share/icons/AM2RLauncher.png
+    install -Dm644 $src/AM2RLauncher/distribution/linux/AM2RLauncher.desktop $out/share/applications/AM2RLauncher.desktop
+
+    # renames binary for desktop file
+    mv $out/bin/AM2RLauncher.Gtk $out/bin/AM2RLauncher
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/AM2R-Community-Developers/AM2RLauncher";
+    description = "Front-end for dealing with AM2R updates and mods";
+    longDescription = ''
+      A front-end application that simplifies installing the latest
+      AM2R-Community-Updates, creating APKs for Android use, as well as Mods for
+      AM2R.
+    '';
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [ nsnelson ];
+    mainProgram = "AM2RLauncher";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/am2rlauncher/deps.json
+++ b/pkgs/am2rlauncher/deps.json
@@ -1,0 +1,152 @@
+[
+  {
+    "pname": "AtkSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-GrOzO4YDMKJNHAnqLF+c44iGYlvazGTOuRLUnuLbwco="
+  },
+  {
+    "pname": "CairoSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-/80xbYSPU8+6twoXRjES8PtV7dKB6fQoe6EqBmawzV8="
+  },
+  {
+    "pname": "Eto.Forms",
+    "version": "2.7.1",
+    "hash": "sha256-OdGDlkKST1qlO4p/jIrX6qVfyywK7wqiY97+Yqtt68M="
+  },
+  {
+    "pname": "Eto.Platform.Gtk",
+    "version": "2.7.1",
+    "hash": "sha256-2msf/Dxo+rxVmJBl57ofWd9cON4YDH8eLl4icXRBPyY="
+  },
+  {
+    "pname": "GdkSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-pQOp2jft19vVN+gSjD0tHfNGucss7ruy1xyys6IHHWQ="
+  },
+  {
+    "pname": "GioSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-/fZBfaKXlrdBuNh1/h0s1++5Ek4OnznXvzJx0uTbHQo="
+  },
+  {
+    "pname": "GLibSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-eAYUYNHF37nIJnk7aRffzBj8b/rluqXERYy358YAd08="
+  },
+  {
+    "pname": "GtkSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-i0XZfzUt9GNaZD1uXNd8x+pb1mPJqYrxQd15XOuHSAA="
+  },
+  {
+    "pname": "LibGit2Sharp",
+    "version": "0.27.0",
+    "hash": "sha256-/4Vr5pXvq1J+5kb4jvd7JkFQ5aiUF1InOViSe53KDFk="
+  },
+  {
+    "pname": "LibGit2Sharp.NativeBinaries",
+    "version": "2.0.319",
+    "hash": "sha256-jvbiwXrsqzzqnMiUQa3oqGshXeDT1miIKFug4NG1pnY="
+  },
+  {
+    "pname": "log4net",
+    "version": "2.0.15",
+    "hash": "sha256-y44EvjW7ZFRCJ3xLa+AGBW81ZI1ZykOEpSVU8EHLAcc="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "2.0.0",
+    "hash": "sha256-IEvBk6wUXSdyCnkj6tHahOJv290tVVT8tyemYcR0Yro="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "5.0.0",
+    "hash": "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "6.0.0",
+    "hash": "sha256-N9EVZbl5w1VnMywGXyaVWzT9lh84iaJ3aD48hIBk1zA="
+  },
+  {
+    "pname": "PangoSharp",
+    "version": "3.24.24.34",
+    "hash": "sha256-/KdH3SA/11bkwPe/AXRph4v4a2cjbUjDvo4+OhkJEOQ="
+  },
+  {
+    "pname": "System.ComponentModel.Annotations",
+    "version": "5.0.0",
+    "hash": "sha256-0pST1UHgpeE6xJrYf5R+U7AwIlH3rVC3SpguilI/MAg="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "4.5.0",
+    "hash": "sha256-TICO+mteKMC+kUTF2ooLBv2E+pwoSa/4gwcbW4nwN7s="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "6.0.0",
+    "hash": "sha256-fPV668Cfi+8pNWrvGAarF4fewdPVEDwlJWvJk0y+Cms="
+  },
+  {
+    "pname": "System.Drawing.Common",
+    "version": "6.0.0",
+    "hash": "sha256-/9EaAbEeOjELRSMZaImS1O8FmUe8j4WuFUw1VOrPyAo="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "4.5.0",
+    "hash": "sha256-AFsKPb/nTk2/mqH/PYpaoI8PLsiKKimaXf+7Mb5VfPM="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "6.0.0",
+    "hash": "sha256-qOyWEBbNr3EjyS+etFG8/zMbuPjA+O+di717JP9Cxyg="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "4.5.0",
+    "hash": "sha256-Z+X1Z2lErLL7Ynt2jFszku6/IgrngO3V1bSfZTBiFIc="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "6.0.0",
+    "hash": "sha256-Wi9I9NbZlpQDXgS7Kl06RIFxY/9674S7hKiYw5EabRY="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "4.5.0",
+    "hash": "sha256-Fa6dX6Gyse1A/RBoin8cVaHQePbfBvp6jjWxUXPhXKQ="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "6.0.0",
+    "hash": "sha256-/MMvtFWGN/vOQfjXdOhet1gsnMgh6lh5DCHimVsnVEs="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.5.0",
+    "hash": "sha256-BkUYNguz0e4NJp1kkW7aJBn3dyH9STwB5N8XqnlCsmY="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "5.0.0",
+    "hash": "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="
+  },
+  {
+    "pname": "System.Windows.Extensions",
+    "version": "6.0.0",
+    "hash": "sha256-N+qg1E6FDJ9A9L50wmVt3xPQV8ZxlG1xeXgFuxO+yfM="
+  }
+]

--- a/pkgs/am2rlauncher/dotnet-8-upgrade.patch
+++ b/pkgs/am2rlauncher/dotnet-8-upgrade.patch
@@ -1,0 +1,52 @@
+diff --git a/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj b/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
+index e5e6191..ab9f228 100644
+--- a/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
++++ b/AM2RLauncher/AM2RLauncher.Gtk/AM2RLauncher.Gtk.csproj
+@@ -2,7 +2,7 @@
+ 	
+   <PropertyGroup>
+     <OutputType>WinExe</OutputType>
+-    <TargetFramework>net6.0</TargetFramework>
++    <TargetFramework>net8.0</TargetFramework>
+     <ApplicationIcon>icon64.ico</ApplicationIcon>
+     <RollForward>LatestMajor</RollForward>
+     <LangVersion>latest</LangVersion>
+diff --git a/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj b/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj
+index 2af5688..a91bb25 100644
+--- a/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj
++++ b/AM2RLauncher/AM2RLauncher.Mac/AM2RLauncher.Mac.csproj
+@@ -2,7 +2,7 @@
+ 	
+   <PropertyGroup>
+     <OutputType>Exe</OutputType>
+-    <TargetFramework>net6.0-macos</TargetFramework>
++    <TargetFramework>net8.0-macos</TargetFramework>
+     <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
+     <SupportedOSPlatformVersion>10.14</SupportedOSPlatformVersion>
+     <RollForward>LatestMajor</RollForward>
+diff --git a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+index be49446..34a842f 100644
+--- a/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
++++ b/AM2RLauncher/AM2RLauncher/AM2RLauncher.csproj
+@@ -1,7 +1,7 @@
+ ﻿<Project Sdk="Microsoft.NET.Sdk">
+ 	
+   <PropertyGroup>
+-    <TargetFramework>netstandard2.0</TargetFramework>
++    <TargetFramework>net8.0</TargetFramework>
+ 	<LangVersion>latest</LangVersion>
+     <ApplicationIcon>Resources\LauncherIcon.ico</ApplicationIcon>
+     <Authors>Lojemiru, Miepee</Authors>
+diff --git a/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj b/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
+index 673ab7a..da3a019 100644
+--- a/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
++++ b/AM2RLauncher/AM2RLauncherLib/AM2RLauncherLib.csproj
+@@ -1,7 +1,7 @@
+ <Project Sdk="Microsoft.NET.Sdk">
+ 
+   <PropertyGroup>
+-    <TargetFramework>netstandard2.0</TargetFramework>
++    <TargetFramework>net8.0</TargetFramework>
+     <LangVersion>default</LangVersion>
+     <Configurations>Debug;Release</Configurations>
+     <Platforms>AnyCPU</Platforms>

--- a/pkgs/am2rlauncher/openssl-1.0.nix
+++ b/pkgs/am2rlauncher/openssl-1.0.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  perl,
+}:
+stdenv.mkDerivation rec {
+  pname = "openssl";
+  version = "1.0.2u";
+
+  src = fetchurl {
+    url = "https://www.openssl.org/source/old/1.0.2/openssl-${version}.tar.gz";
+    sha256 = "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16";
+  };
+
+  nativeBuildInputs = [ perl ];
+
+  configurePhase = ''
+    runHook preConfigure
+    ./Configure linux-elf shared no-asm --prefix=$out --openssldir=$out/etc/ssl
+    runHook postConfigure
+  '';
+
+  enableParallelBuilding = false;
+
+  installTargets = [ "install_sw" ];
+
+  meta = {
+    homepage = "https://www.openssl.org/";
+    description = "OpenSSL 1.0.2 built 32-bit for the AM2R GameMaker runner";
+    license = lib.licenses.openssl;
+    platforms = [ "i686-linux" ];
+  };
+}


### PR DESCRIPTION
The nixpkgs am2rlauncher is marked broken and its FHS can't launch the 32-bit GameMaker game on current nixpkgs. Vendors it here with a fixed am2r-run FHS: webkitgtk_4_1 shimmed under the 4.0 soname, a from-source 32-bit openssl 1.0.2, and mesa/glibc matching the host GL driver.

CI only builds it; the game launch needs a GPU and AM2R_11.zip:
- [x] launcher UI opens
- [x] a re-created profile launches the game to a window