### PR TITLE
feat(reversepuck): package the OpenPuck Steam Deck forwarder

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
                   "battleship"
                   "openjkdf2"
                   "openjkdf2-gles"
+                  "reversepuck"
                 ];
                 "x86_64-linux" = [
                   "message-bridge"

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -14,6 +14,7 @@ let
     quakejs = ./quakejs.nix;
     hoarder-miniflux-webhook = ./hoarder-miniflux-webhook.nix;
     zz-sdjson = ./zz-sdjson.nix;
+    reversepuck = ./reversepuck.nix;
   };
 
   # NixOS VM tests. Each value is a function { pkgs, self }: pkgs.nixosTest { ... }

--- a/modules/nixos/reversepuck.nix
+++ b/modules/nixos/reversepuck.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkIf
+    mdDoc
+    ;
+  cfg = config.programs.reversepuck;
+in
+{
+  options = {
+    programs.reversepuck = {
+      enable = mkEnableOption (mdDoc "ReversePuck Steam Deck forwarder for OpenPuck");
+      package = mkPackageOption pkgs "reversepuck" { };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+
+    services.udev.extraRules = ''
+      # nRF ReversePuck dongle CDC link (Valve 28DE:1302) -> /dev/ttyACM*
+      SUBSYSTEM=="tty", ATTRS{idVendor}=="28de", ATTRS{idProduct}=="1302", TAG+="uaccess"
+      # Steam Deck built-in controller (Valve 28DE:1205) for USB-level detach
+      SUBSYSTEM=="usb", ATTR{idVendor}=="28de", ATTR{idProduct}=="1205", TAG+="uaccess"
+    '';
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -21,4 +21,5 @@ final: prev: {
   battleship = final.callPackage ./pkgs/battleship { };
   openjkdf2 = final.callPackage ./pkgs/openjkdf2 { };
   openjkdf2-gles = final.callPackage ./pkgs/openjkdf2/gles.nix { };
+  reversepuck = final.callPackage ./pkgs/reversepuck { };
 }

--- a/pkgs/reversepuck/default.nix
+++ b/pkgs/reversepuck/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  makeWrapper,
+}:
+
+python3.pkgs.buildPythonApplication (finalAttrs: {
+  pname = "reversepuck";
+  version = "0.9.31";
+  pyproject = false;
+
+  src = fetchFromGitHub {
+    owner = "safijari";
+    repo = "openpuck";
+    tag = finalAttrs.version;
+    hash = "sha256-86GOaQQ1yIVzErIZFCwK6zVc4MatVewMp7Rf/hHVaPg=";
+  };
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    pyserial
+    pygame
+    pyusb
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/reversepuck
+    cp ReversePuck/*.py $out/share/reversepuck/
+
+    makeWrapper ${python3.interpreter} $out/bin/reversepuck \
+      --add-flags "$out/share/reversepuck/openctrl.py" \
+      --prefix PYTHONPATH : "$PYTHONPATH"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Steam Deck forwarder that emulates a wireless Steam Controller 2 via OpenPuck";
+    homepage = "https://github.com/safijari/openpuck";
+    license = lib.licenses.agpl3Only;
+    mainProgram = "reversepuck";
+    maintainers = with lib.maintainers; [ devusb ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Packages ReversePuck — the Steam Deck-side forwarder from OpenPuck that turns the Deck into a wireless Steam Controller 2 — with pyserial/pygame/pyusb baked in, so it no longer bootstraps `uv` at runtime. Adds a `programs.reversepuck` NixOS module whose `uaccess` udev rules grant the active user access to the nRF CDC link and the Deck controller, replacing the upstream per-boot `sudo setup.sh`.